### PR TITLE
Fix template

### DIFF
--- a/templates/admin/emailers/smtpssl.tpl
+++ b/templates/admin/emailers/smtpssl.tpl
@@ -36,7 +36,7 @@
 					<label for="emailer:local:password">Password</label>
 					<!-- Only after https://github.com/designcreateplay/NodeBB/commit/6f129d9c68f998c9de08618c9b56f06f6841abd7 -->
 					<input type="password" class="form-control" id="emailer:local:password" data-field="emailer:local:password" />
-					<!-- If you're using an older commit, use type="text". Or pulling the up-to-date version would be even better ;) -->
+					<!-- When you're using an older commit, use type="text". Or pulling the up-to-date version would be even better ;) -->
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
The `<!-- If` caused a template.js error:

```
17/3 10:06 [1747] - error: SyntaxError: Invalid regular expression: /<!--[\s]*IF !(you're using an older commit, use type="text".)? Or pulling the up-to-date version would be even better ;)[\s]*-->([\s\S]*?)<!--[\s]*ENDIF !(you're using an older commit[\s]*-->/: Unmatched ')'
    at new RegExp (<anonymous>)
    at makeConditionalRegex (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:206:10)
    at checkConditional (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:229:32)
    at checkConditionals (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:225:27)
    at parseValue (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:369:14)
    at parse (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:390:17)
    at cleanup (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:433:27)
    at parse (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:400:15)
    at parseTemplate (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:123:14)
    at Object.templates.parse (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:109:11)
SyntaxError: Invalid regular expression: /<!--[\s]*IF !(you're using an older commit, use type="text".)? Or pulling the up-to-date version would be even better ;)[\s]*-->([\s\S]*?)<!--[\s]*ENDIF !(you're using an older commit[\s]*-->/: Unmatched ')'
    at new RegExp (<anonymous>)
    at makeConditionalRegex (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:206:10)
    at checkConditional (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:229:32)
    at checkConditionals (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:225:27)
    at parseValue (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:369:14)
    at parse (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:390:17)
    at cleanup (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:433:27)
    at parse (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:400:15)
    at parseTemplate (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:123:14)
    at Object.templates.parse (/data/nettle-server/55075192e1e933cedae8b279/55016a31642bde40073426fe_qanda_1426600227699/0.6.1/node_modules/templates.js/lib/templates.js:109:11)
```
